### PR TITLE
Create ptrace.c

### DIFF
--- a/Ring3/ptrace.c
+++ b/Ring3/ptrace.c
@@ -1,0 +1,19 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <sys/ptrace.h>
+#include <stdarg.h>
+
+
+typedef long (*orig_ptrace_func_t)(enum __ptrace_request request, ...);
+
+long ptrace(enum __ptrace_request request, ...) {
+    fprintf(stderr, "[HOOK] request blocked %d\n", request);
+
+    
+    errno = EPERM;
+    return -1;
+}
+
+


### PR DESCRIPTION
hey buddy,

i created a small area program that blocks all programs from using ptrace(), which is the system call used for debugging or monitoring another program you can upload in ring3 for me as contributing it ,
code:
```#define _GNU_SOURCE
#include <stdio.h>
#include <dlfcn.h>
#include <errno.h>
#include <sys/ptrace.h>
#include <stdarg.h>


typedef long (*orig_ptrace_func_t)(enum __ptrace_request request, ...);

long ptrace(enum __ptrace_request request, ...) {
    fprintf(stderr, "[HOOK] request blocked %d\n", request);

    
    errno = EPERM;
    return -1;
}
```

eg:
<img width="737" height="547" alt="image" src="https://github.com/user-attachments/assets/070fef9c-0091-4b68-8b76-ee284549cf1a" />
